### PR TITLE
Fix urls on cloned documents to avoid overwriting originals

### DIFF
--- a/src/multiplelayouts.plugin.coffee
+++ b/src/multiplelayouts.plugin.coffee
@@ -50,12 +50,15 @@ module.exports = (BasePlugin) ->
 					newDoc.set(
 						filename: null
 					)
+					relativePath = document.get('relativeOutDirPath') + '/' + document.get('basename') + '-' + layout + '.' + document.get('extensions').join('.')
 					newDoc.setMeta(
 						fullPath: null  # treat it as a virtual document
-						relativePath: document.get('relativeOutDirPath') + '/' + document.get('basename') + '-' + layout + '.' + document.get('extensions').join('.')
+						relativePath: relativePath
 						layout: layout
 						additionalLayoutFor: document.id
-						additionalLayouts: null
+						additionalLayouts: null,
+						url: relativePath,
+						urls: [relativePath]
 					)
 					newDoc.normalize (err) ->
 						return complete(err) if err


### PR DESCRIPTION
This is the second part of the fix for #9 - this ensures that the new doc doesn't overwrite the original due to having the same url.
